### PR TITLE
Feat/customer subscriptions endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Things you may want to cover:
 ### Schema design
 <img width="622" alt="Screen Shot 2022-09-21 at 9 39 47 AM" src="https://user-images.githubusercontent.com/60715457/191549065-3077183e-911f-4746-bedd-7b74c8baea9c.png">
 
-### Subscription endpoint
+### Subscription Creation endpoint
 Request
 ```
 POST /api/v1/subscriptions
@@ -42,4 +42,44 @@ Response
 ```
 status: 201
 ```
+
+### Customer Subscription retrieval endpoint
+Request
+```
+get '/api/v1/subscriptions'
+parameters = {
+        customer_email: "customer@email.com"
+        }
+```
+Response
+```
+{"data"=>
+  [
+    {
+      "id"=>"27",
+      "type"=>"subscription",
+      "attributes"=>
+        {
+          "title"=>"Green Tea", 
+          "price"=>5.5, 
+          "status"=>"Active", 
+          "frequency"=>"Weekly"
+        }
+    },
+   {
+      "id"=>"28",
+      "type"=>"subscription",
+      "attributes"=>
+        {
+          "title"=>"Black Tea", 
+          "price"=>5.5, 
+          "status"=>"Active", 
+          "frequency"=>"Weekly"
+        }
+    }
+  ]
+}
+```
+
+
 

--- a/README.md
+++ b/README.md
@@ -29,55 +29,61 @@ Things you may want to cover:
 ### Subscription Creation endpoint
 Request
 ```
-POST /api/v1/subscriptions
+POST /api/v1/customers/:id/subscriptions
 parameters = {
           title: 'Green Tea',
           price: 3.25,
           status: 'active',
           frequency: 'weekly',
-          customer_email: 'customer@email.com'
+          tea_id: 1
         }
 ```
 Response
 ```
-status: 201
+{
+    "data": {
+        "id": "3",
+        "type": "subscription",
+        "attributes": {
+            "title": "Green Tea",
+            "price": 3.5,
+            "status": "active",
+            "frequency": "monthly"
+        }
+    }
+}
 ```
 
 ### Customer Subscription retrieval endpoint
 Request
 ```
-get '/api/v1/subscriptions'
-parameters = {
-        customer_email: "customer@email.com"
-        }
+get '/api/v1/customers/:id/subscriptions'
 ```
 Response
 ```
-{"data"=>
-  [
-    {
-      "id"=>"27",
-      "type"=>"subscription",
-      "attributes"=>
+{
+    "data": [
         {
-          "title"=>"Green Tea", 
-          "price"=>5.5, 
-          "status"=>"Active", 
-          "frequency"=>"Weekly"
-        }
-    },
-   {
-      "id"=>"28",
-      "type"=>"subscription",
-      "attributes"=>
+            "id": "1",
+            "type": "subscription",
+            "attributes": {
+                "title": "Green Tea",
+                "price": 3.5,
+                "status": "active",
+                "frequency": "monthly"
+            }
+        },
         {
-          "title"=>"Black Tea", 
-          "price"=>5.5, 
-          "status"=>"Active", 
-          "frequency"=>"Weekly"
+            "id": "3",
+            "type": "subscription",
+            "attributes": {
+                "title": "Green Tea",
+                "price": 3.5,
+                "status": "active",
+                "frequency": "monthly"
+            }
         }
-    }
-  ]
+    ]
 }
 ```
 

--- a/app/controllers/api/v1/customer_subscriptions_controller.rb
+++ b/app/controllers/api/v1/customer_subscriptions_controller.rb
@@ -1,13 +1,11 @@
 class Api::V1::CustomerSubscriptionsController < ApplicationController
 
   def create
-    # binding.pry
     subscription = Subscription.create(subscription_params)
     render json: SubscriptionSerializer.new(subscription), status: :created
   end
 
   def show
-    # binding.pry
     customer = Customer.find(params[:customer_id])
     subscriptions = customer.subscriptions
     render json: SubscriptionSerializer.new(subscriptions), status: :ok

--- a/app/controllers/api/v1/customer_subscriptions_controller.rb
+++ b/app/controllers/api/v1/customer_subscriptions_controller.rb
@@ -2,15 +2,12 @@ class Api::V1::CustomerSubscriptionsController < ApplicationController
 
   def create
     # binding.pry
-    tea = Tea.find_by(title: params[:title])
-    customer = Customer.find_by(email: params[:customer_email])
-    subscription = Subscription.create(title: params[:title], price: params[:price], status: params[:status], frequency: params[:frequency], tea_id: tea.id, customer_id: customer.id)
+    subscription = Subscription.create(subscription_params)
     render json: SubscriptionSerializer.new(subscription), status: :created
   end
 
   def show
     # binding.pry
-    # customer = Customer.find_by(email: params[:customer_email])
     customer = Customer.find(params[:customer_id])
     subscriptions = customer.subscriptions
     render json: SubscriptionSerializer.new(subscriptions), status: :ok
@@ -18,6 +15,6 @@ class Api::V1::CustomerSubscriptionsController < ApplicationController
 
   private
   def subscription_params
-    params.permit(:title, :price, :status, :frequency)
+    params.permit(:title, :price, :status, :frequency, :tea_id, :customer_id)
   end
 end

--- a/app/controllers/api/v1/customer_subscriptions_controller.rb
+++ b/app/controllers/api/v1/customer_subscriptions_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::SubscriptionsController < ApplicationController
+class Api::V1::CustomerSubscriptionsController < ApplicationController
 
   def create
     # binding.pry
@@ -9,7 +9,9 @@ class Api::V1::SubscriptionsController < ApplicationController
   end
 
   def show
-    customer = Customer.find_by(email: params[:customer_email])
+    # binding.pry
+    # customer = Customer.find_by(email: params[:customer_email])
+    customer = Customer.find(params[:customer_id])
     subscriptions = customer.subscriptions
     render json: SubscriptionSerializer.new(subscriptions), status: :ok
   end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -7,6 +7,12 @@ class Api::V1::SubscriptionsController < ApplicationController
     render status: :created
   end
 
+  def show
+    customer = Customer.find_by(email: params[:customer_email])
+    subscriptions = customer.subscriptions
+    render json: SubscriptionSerializer.new(subscriptions), status: :ok
+  end
+
   private
   def subscription_params
     params.permit(:title, :price, :status, :frequency)

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,10 +1,11 @@
 class Api::V1::SubscriptionsController < ApplicationController
 
   def create
+    # binding.pry
     tea = Tea.find_by(title: params[:title])
     customer = Customer.find_by(email: params[:customer_email])
     subscription = Subscription.create(title: params[:title], price: params[:price], status: params[:status], frequency: params[:frequency], tea_id: tea.id, customer_id: customer.id)
-    render status: :created
+    render json: SubscriptionSerializer.new(subscription), status: :created
   end
 
   def show

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,0 +1,4 @@
+class SubscriptionSerializer
+  include JSONAPI::Serializer
+  attributes :title, :price, :status, :frequency
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post 'subscriptions', to: 'subscriptions#create'
+      get 'subscriptions', to: 'subscriptions#show'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      post 'subscriptions', to: 'customer_subscriptions#create'
       resources :customers do
+        post 'subscriptions', to: 'customer_subscriptions#create'
         # resources :subscriptions, only: [:show]
         get 'subscriptions', to: 'customer_subscriptions#show'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,11 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      post 'subscriptions', to: 'subscriptions#create'
-      get 'subscriptions', to: 'subscriptions#show'
+      post 'subscriptions', to: 'customer_subscriptions#create'
+      resources :customers do
+        # resources :subscriptions, only: [:show]
+        get 'subscriptions', to: 'customer_subscriptions#show'
+      end
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Customer.create(first_name: "Jane", last_name: "Powell", email: "jpowell@email.com", address: "123 sonnybrook lane")
+Customer.create(first_name: "Judy", last_name: "Garland", email: "jgarland@email.com", address: "123 hollywood lane")
+
+Tea.create(title: "Green Tea", description: "refreshing green tea", temperature: 80, brew_time: 3)
+Tea.create(title: "Lavender Tea", description: "Soothing tea", temperature: 80, brew_time: 3)
+Tea.create(title: "Ginger Tea", description: "Good for colds", temperature: 70, brew_time: 4)

--- a/spec/factories/subscription.rb
+++ b/spec/factories/subscription.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :subscription do
+    price { 5.50 }
+    status { "Active" }
+    frequency { "Weekly" }
+  end
+end

--- a/spec/requests/api/v1/subscription_request.rb
+++ b/spec/requests/api/v1/subscription_request.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'Subscription Requests' do
 
-  context 'happy path' do
-    describe 'POST api/v1/subscription' do
+  
+  describe 'POST api/v1/subscriptions' do
+    context 'success' do
       it 'creates a subscription in the database associated with a customer and a tea' do
         customer = create(:customer)
         tea = create(:tea)
@@ -38,7 +39,28 @@ RSpec.describe 'Subscription Requests' do
         expect(tea.subscriptions.length).to eq(1)
         expect(black_tea.subscriptions.length).to eq(1)
       end
-    end 
+    end
+  end
+
+  describe 'GET api/v1/subscriptions' do
+    context 'success' do
+      it 'returns all subscriptions for a given customer' do
+        customer = create(:customer)
+        tea = create(:tea)
+        black_tea = create(:tea, title: "Black Tea")
+        subscription1 = create(:subscription, title: "Green Tea", tea_id: tea.id, customer_id: customer.id)
+        subscription2 = create(:subscription, title: "Black Tea", tea_id: black_tea.id, customer_id: customer.id)
+
+        get '/api/v1/subscriptions', params: {customer_email: "Customer@email.com"}
+
+        binding.pry
+        expect(response.status).to eq(200)
+        json = JSON.parse(response.body, symbolize_names: true)
+        data = json[:data] 
+        expect(data).to be_a(Hash)
+        expect(data.length).to eq(2)
+      end
+    end
   end
 
 end

--- a/spec/requests/api/v1/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscription_request_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe 'Subscription Requests' do
           price: 3.25,
           status: 'active',
           frequency: 'weekly',
-          customer_email: 'customer@email.com'
+          tea_id: tea.id
         }
         expect do
-          post '/api/v1/subscriptions', params: parameters
+          post "/api/v1/customers/#{customer.id}/subscriptions", params: parameters
         end.to change { Subscription.count }.by(1) 
 
         expect(response.status).to eq(201)
@@ -28,11 +28,11 @@ RSpec.describe 'Subscription Requests' do
           price: 3.50,
           status: 'active',
           frequency: 'monthly',
-          customer_email: 'customer@email.com'
+          tea_id: black_tea.id
         }
 
         expect do
-          post '/api/v1/subscriptions', params: parameters2
+          post "/api/v1/customers/#{customer.id}/subscriptions", params: parameters2
         end.to change { Subscription.count }.by(1)
         expect(Customer.find(customer.id).subscriptions.length).to eq(2)
         expect(tea.subscriptions.length).to eq(1)
@@ -50,7 +50,7 @@ RSpec.describe 'Subscription Requests' do
         subscription1 = create(:subscription, title: "Green Tea", tea_id: tea.id, customer_id: customer.id)
         subscription2 = create(:subscription, title: "Black Tea", tea_id: black_tea.id, customer_id: customer.id)
 
-        get "/api/v1/customers/#{customer.id}/subscriptions"#, params: {customer_email: "customer@email.com"}
+        get "/api/v1/customers/#{customer.id}/subscriptions"
 
         expect(response.status).to eq(200)
         json = JSON.parse(response.body, symbolize_names: true)

--- a/spec/requests/api/v1/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscription_request_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Subscription Requests' do
 
-  
   describe 'POST api/v1/subscriptions' do
     context 'success' do
       it 'creates a subscription in the database associated with a customer and a tea' do
@@ -51,13 +50,12 @@ RSpec.describe 'Subscription Requests' do
         subscription1 = create(:subscription, title: "Green Tea", tea_id: tea.id, customer_id: customer.id)
         subscription2 = create(:subscription, title: "Black Tea", tea_id: black_tea.id, customer_id: customer.id)
 
-        get '/api/v1/subscriptions', params: {customer_email: "Customer@email.com"}
+        get '/api/v1/subscriptions', params: {customer_email: "customer@email.com"}
 
-        binding.pry
         expect(response.status).to eq(200)
         json = JSON.parse(response.body, symbolize_names: true)
         data = json[:data] 
-        expect(data).to be_a(Hash)
+        expect(data).to be_a(Array)
         expect(data.length).to eq(2)
       end
     end

--- a/spec/requests/api/v1/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscription_request_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Subscription Requests' do
         subscription1 = create(:subscription, title: "Green Tea", tea_id: tea.id, customer_id: customer.id)
         subscription2 = create(:subscription, title: "Black Tea", tea_id: black_tea.id, customer_id: customer.id)
 
-        get '/api/v1/subscriptions', params: {customer_email: "customer@email.com"}
+        get "/api/v1/customers/#{customer.id}/subscriptions"#, params: {customer_email: "customer@email.com"}
 
         expect(response.status).to eq(200)
         json = JSON.parse(response.body, symbolize_names: true)


### PR DESCRIPTION
Exposes and endpoint which returns a customers subscriptions. Created some seed data of customers and teas to be able to test the endpoints in postman. Updated subscription routes to be nested in customer resource and use customer and tea id in subscription creation and retrieval instead of having to use the email and title to find the customer or tea. Used subscription serializer to return subscription upon post request, instead of just returning a status code. Updated ReadME to reflect these changes.