### PR TITLE
Feat/cancel subscription endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Things you may want to cover:
 ### Subscription Creation endpoint
 Request
 ```
-POST /api/v1/customers/:id/subscriptions
+POST /api/v1/customers/:customer_id/subscriptions
 parameters = {
           title: 'Green Tea',
           price: 3.25,
@@ -38,7 +38,7 @@ parameters = {
           tea_id: 1
         }
 ```
-Response
+Response - status: 201
 ```
 {
     "data": {
@@ -57,9 +57,9 @@ Response
 ### Customer Subscription retrieval endpoint
 Request
 ```
-get '/api/v1/customers/:id/subscriptions'
+get '/api/v1/customers/:customer_id/subscriptions'
 ```
-Response
+Response - status: 200
 ```
 {
     "data": [
@@ -86,6 +86,25 @@ Response
     ]
 }
 ```
-
+### Cancel Subscription Endpoint
+Request
+```
+patch '/api/v1/customers/:customer_id/subscriptions/:id'
+```
+Response - status: 202
+```
+{
+    "data": {
+        "id": "1",
+        "type": "subscription",
+        "attributes": {
+            "title": "Green Tea",
+            "price": 3.5,
+            "status": "Cancelled",
+            "frequency": "monthly"
+        }
+    }
+}
+```
 
 

--- a/app/controllers/api/v1/customer_subscriptions_controller.rb
+++ b/app/controllers/api/v1/customer_subscriptions_controller.rb
@@ -5,10 +5,16 @@ class Api::V1::CustomerSubscriptionsController < ApplicationController
     render json: SubscriptionSerializer.new(subscription), status: :created
   end
 
-  def show
+  def index
     customer = Customer.find(params[:customer_id])
     subscriptions = customer.subscriptions
     render json: SubscriptionSerializer.new(subscriptions), status: :ok
+  end
+
+  def update
+    subscription = Subscription.find(params[:id])
+    subscription.update(status: "Cancelled")
+    render json: SubscriptionSerializer.new(subscription),  status: :accepted
   end
 
   private

--- a/app/controllers/api/v1/customer_subscriptions_controller.rb
+++ b/app/controllers/api/v1/customer_subscriptions_controller.rb
@@ -12,9 +12,13 @@ class Api::V1::CustomerSubscriptionsController < ApplicationController
   end
 
   def update
-    subscription = Subscription.find(params[:id])
-    subscription.update(status: "Cancelled")
-    render json: SubscriptionSerializer.new(subscription),  status: :accepted
+    subscription = Subscription.find_by_id(params[:id])
+    if subscription
+      subscription.update(status: "Cancelled")
+      render json: SubscriptionSerializer.new(subscription),  status: :accepted
+    else
+      render json: { errors: "Invalid Subscription ID" }, status: :not_found
+    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :customers do
-        post 'subscriptions', to: 'customer_subscriptions#create'
-        # resources :subscriptions, only: [:show]
-        get 'subscriptions', to: 'customer_subscriptions#show'
+        resources :subscriptions, only: [:create, :index, :update], controller: :customer_subscriptions
       end
     end
   end

--- a/spec/requests/api/v1/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscription_request_spec.rb
@@ -72,14 +72,14 @@ RSpec.describe 'Subscription Requests' do
         
         expect(subscription1.status).to eq("Active")
 
-        patch "/api/v1/customers/#{customer.id}/subscriptions/#{subscritpion1.id}"
+        patch "/api/v1/customers/#{customer.id}/subscriptions/#{subscription1.id}"
 
         expect(response.status).to eq(202)
         json = JSON.parse(response.body, symbolize_names: true)
         data = json[:data] 
-        expect(data).to be_a(Array)
-        expect(data.length).to eq(2)
-        expect(subscription1.status).to eq("Cancelled")
+        expect(data).to be_a(Hash)
+        expect(data[:attributes][:status]).to eq("Cancelled")
+        expect(Subscription.find(subscription1.id).status).to eq("Cancelled")
       end
     end
   end

--- a/spec/requests/api/v1/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscription_request_spec.rb
@@ -82,6 +82,18 @@ RSpec.describe 'Subscription Requests' do
         expect(Subscription.find(subscription1.id).status).to eq("Cancelled")
       end
     end
+
+    context 'failure' do
+      it 'returns 404 if there is no subscription with the given id' do
+        customer = create(:customer)
+        tea = create(:tea)
+
+        patch "/api/v1/customers/#{customer.id}/subscriptions/1"
+
+        expect(response.status).to eq(404)
+        expect(response.errors).to eq("Invalid Subscription ID")
+      end
+    end
   end
 
 end

--- a/spec/requests/api/v1/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscription_request_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe 'Subscription Requests' do
         patch "/api/v1/customers/#{customer.id}/subscriptions/1"
 
         expect(response.status).to eq(404)
-        expect(response.errors).to eq("Invalid Subscription ID")
+        json = JSON.parse(response.body, symbolize_names: true) 
+        expect(json[:errors]).to eq("Invalid Subscription ID")
       end
     end
   end

--- a/spec/requests/api/v1/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscription_request_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Subscription Requests' do
 
-  describe 'POST api/v1/subscriptions' do
+  describe 'POST api/v1/customers/:id/subscriptions' do
     context 'success' do
       it 'creates a subscription in the database associated with a customer and a tea' do
         customer = create(:customer)
@@ -41,7 +41,7 @@ RSpec.describe 'Subscription Requests' do
     end
   end
 
-  describe 'GET api/v1/subscriptions' do
+  describe 'GET api/v1/customers/:id/subscriptions' do
     context 'success' do
       it 'returns all subscriptions for a given customer' do
         customer = create(:customer)
@@ -57,6 +57,29 @@ RSpec.describe 'Subscription Requests' do
         data = json[:data] 
         expect(data).to be_a(Array)
         expect(data.length).to eq(2)
+      end
+    end
+  end
+
+  describe 'PATCH api/v1/customers/:id/subscriptions/:id' do
+    context 'success' do
+      it 'changes subscription status to cancelled' do
+        customer = create(:customer)
+        tea = create(:tea)
+        black_tea = create(:tea, title: "Black Tea")
+        subscription1 = create(:subscription, title: "Green Tea", tea_id: tea.id, customer_id: customer.id)
+        subscription2 = create(:subscription, title: "Black Tea", tea_id: black_tea.id, customer_id: customer.id)
+        
+        expect(subscription1.status).to eq("Active")
+
+        patch "/api/v1/customers/#{customer.id}/subscriptions/#{subscritpion1.id}"
+
+        expect(response.status).to eq(202)
+        json = JSON.parse(response.body, symbolize_names: true)
+        data = json[:data] 
+        expect(data).to be_a(Array)
+        expect(data.length).to eq(2)
+        expect(subscription1.status).to eq("Cancelled")
       end
     end
   end


### PR DESCRIPTION
Expose endpoint to cancel subscription by updating the status to be cancelled on the specified subscription. Handle error and return 404 and error message when invalid subscription id is given.